### PR TITLE
Ability to post spoilers & Removed padding from toots

### DIFF
--- a/app/src/main/java/eu/theinvaded/mastondroid/data/MastodroidService.java
+++ b/app/src/main/java/eu/theinvaded/mastondroid/data/MastodroidService.java
@@ -108,6 +108,7 @@ public interface MastodroidService {
     @FormUrlEncoded
     @POST("/api/v1/statuses")
     Observable<Toot> postStatusReplyWithMedia(@Field("status") String toot,
+                                              @Field("spoiler_text") String spoilerText,
                                 @Field("in_reply_to_id") long replyToId,
                                 @Field("media_id") long mediaId,
                                 @Field("sensitive") boolean sensitive,
@@ -116,6 +117,7 @@ public interface MastodroidService {
     @FormUrlEncoded
     @POST("/api/v1/statuses")
     Observable<Toot> postStatusReply(@Field("status") String toot,
+                                     @Field("spoiler_text") String spoilerText,
                                      @Field("in_reply_to_id") long replyToId,
                                      @Field("sensitive") boolean sensitive,
                                      @Field("visibility") String visibility);
@@ -123,6 +125,7 @@ public interface MastodroidService {
     @FormUrlEncoded
     @POST("/api/v1/statuses")
     Observable<Toot> postStatusWithMedia(@Field("status") String toot,
+                                         @Field("spoiler_text") String spoilerText,
                                 @Field("media_id") long mediaId,
                                 @Field("sensitive") boolean sensitive,
                                 @Field("visibility") String visibility);
@@ -130,6 +133,7 @@ public interface MastodroidService {
     @FormUrlEncoded
     @POST("/api/v1/statuses")
     Observable<Toot> postStatus(@Field("status") String toot,
+                                @Field("spoiler_text") String spoilerText,
                                 @Field("sensitive") boolean sensitive,
                                 @Field("visibility") String visibility);
 }

--- a/app/src/main/java/eu/theinvaded/mastondroid/model/Toot.java
+++ b/app/src/main/java/eu/theinvaded/mastondroid/model/Toot.java
@@ -22,6 +22,8 @@ public class Toot implements Parcelable {
     public Date createdAt;
     @SerializedName("sensitive")
     public boolean sensitive;
+    @SerializedName("spoiler_text")
+    public String spoiler_text;
     @SerializedName("account")
     public MastodonAccount account;
     @Nullable
@@ -61,6 +63,7 @@ public class Toot implements Parcelable {
         dest.writeLong(this.id);
         dest.writeLong(this.createdAt != null ? this.createdAt.getTime() : -1);
         dest.writeByte(this.sensitive ? (byte) 1 : (byte) 0);
+        dest.writeString(this.spoiler_text);
         dest.writeParcelable(this.account, flags);
         dest.writeList(this.mediaAttachments);
         dest.writeList(this.mentions);
@@ -86,6 +89,7 @@ public class Toot implements Parcelable {
         long tmpCreatedAt = in.readLong();
         this.createdAt = tmpCreatedAt == -1 ? null : new Date(tmpCreatedAt);
         this.sensitive = in.readByte() != 0;
+        this.spoiler_text = in.readString();
         this.account = in.readParcelable(MastodonAccount.class.getClassLoader());
         this.mediaAttachments = new ArrayList<>();
         in.readList(this.mediaAttachments, MediaAttachments.class.getClassLoader());

--- a/app/src/main/java/eu/theinvaded/mastondroid/utils/StringUtils.java
+++ b/app/src/main/java/eu/theinvaded/mastondroid/utils/StringUtils.java
@@ -1,5 +1,7 @@
 package eu.theinvaded.mastondroid.utils;
 
+import android.text.Spannable;
+import android.text.SpannableStringBuilder;
 /**
  * Created by alin on 27.12.2016.
  */
@@ -17,5 +19,18 @@ public class StringUtils {
 
     public static boolean isNotNullOrEmpty(String string) {
         return string != null && !string.equals(EMPTY);
+    }
+
+    public static SpannableStringBuilder trimSpannable(SpannableStringBuilder spannable) {
+        int trimCount = 0;
+
+        String text = spannable.toString();
+
+        while (text.length() > 0 && text.endsWith("\n")) {
+            text = text.substring(0, text.length() - 1);
+            trimCount += 1;
+        }
+
+        return spannable.delete(spannable.length() - trimCount, spannable.length());
     }
 }

--- a/app/src/main/java/eu/theinvaded/mastondroid/viewmodel/ItemTootViewModel.java
+++ b/app/src/main/java/eu/theinvaded/mastondroid/viewmodel/ItemTootViewModel.java
@@ -11,6 +11,7 @@ import android.support.v4.content.ContextCompat;
 import android.text.Html;
 import android.text.Spannable;
 import android.text.Spanned;
+import android.text.SpannableStringBuilder;
 import android.text.TextPaint;
 import android.text.style.ClickableSpan;
 import android.text.style.URLSpan;
@@ -18,6 +19,7 @@ import android.text.style.UnderlineSpan;
 import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
+
 
 import com.squareup.picasso.Picasso;
 
@@ -32,6 +34,7 @@ import eu.theinvaded.mastondroid.data.MastodroidService;
 import eu.theinvaded.mastondroid.model.MastodonAccount;
 import eu.theinvaded.mastondroid.model.StatusType;
 import eu.theinvaded.mastondroid.model.Toot;
+import eu.theinvaded.mastondroid.utils.StringUtils;
 import rx.Observer;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
@@ -110,7 +113,7 @@ public class ItemTootViewModel extends BaseObservable implements TootViewModelCo
         if (toot.statusType == null)
             return status;
 
-        statusTypeVisible.set(View.VISIBLE);
+        //statusTypeVisible.set(View.VISIBLE);
         switch (toot.statusType) {
             case Boost:
                 statusTypeBoost.set(View.VISIBLE);
@@ -146,6 +149,7 @@ public class ItemTootViewModel extends BaseObservable implements TootViewModelCo
 
     public Spanned getContent() {
         final String content;
+        String contentTemp;
         if (toot.statusType == StatusType.Boost) {
             content = toot.reblog.content;
             statusTypeVisible.set(View.VISIBLE);
@@ -161,7 +165,6 @@ public class ItemTootViewModel extends BaseObservable implements TootViewModelCo
         } else {
             spanned = (Spannable) Html.fromHtml(content);
         }
-
         // Restyle link: remove underline and change color
         // Also handle clicks
         for (final URLSpan span : spanned.getSpans(0, spanned.length(), URLSpan.class)) {
@@ -191,7 +194,9 @@ public class ItemTootViewModel extends BaseObservable implements TootViewModelCo
             }, spanned.getSpanStart(span), spanned.getSpanEnd(span), 0);
             spanned.removeSpan(span);
         }
-        return spanned;
+        final Spannable spannedTrimmed;
+        spannedTrimmed = StringUtils.trimSpannable((SpannableStringBuilder) spanned);
+        return spannedTrimmed;
     }
 
 

--- a/app/src/main/java/eu/theinvaded/mastondroid/viewmodel/ReplyViewModel.java
+++ b/app/src/main/java/eu/theinvaded/mastondroid/viewmodel/ReplyViewModel.java
@@ -30,10 +30,12 @@ public class ReplyViewModel extends BaseObservable implements ReplyViewModelCont
     private ReplyViewModelContract.ReplyView replyView;
 
     public ObservableField<String> tootText = new ObservableField<>("");
+    public ObservableField<String> spoilerText = new ObservableField<>("");
     public ObservableField<String> remainingCharsText = new ObservableField<>("500");
     public ObservableInt remainingChars = new ObservableInt(500);
     public ObservableBoolean isPrivate = new ObservableBoolean(false);
     public ObservableBoolean notDisplayPublic = new ObservableBoolean(false);
+    public ObservableBoolean showContentWarning = new ObservableBoolean(false);
 
     public long replyToId;
 
@@ -83,8 +85,13 @@ public class ReplyViewModel extends BaseObservable implements ReplyViewModelCont
                 : notDisplayPublic.get()
                     ? "unlisted"
                     : "public";
+        String spoilerTextTemp = spoilerText.get();
+        if(!showContentWarning.get())
+        {
+            spoilerTextTemp = "";
+        }
         if (replyToId == 0) {
-            service.postStatus(tootText.get(), false, statusVisibility)
+            service.postStatus(tootText.get(), spoilerTextTemp, false, statusVisibility)
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribeOn(Schedulers.io())
                     .subscribe(new Action1<Toot>() {
@@ -101,7 +108,7 @@ public class ReplyViewModel extends BaseObservable implements ReplyViewModelCont
                         }
                     });
         } else {
-            service.postStatusReply(tootText.get(), replyToId, false, statusVisibility)
+            service.postStatusReply(tootText.get(), spoilerTextTemp, replyToId, false, statusVisibility)
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribeOn(Schedulers.io())
                     .subscribe(new Action1<Toot>() {
@@ -117,7 +124,6 @@ public class ReplyViewModel extends BaseObservable implements ReplyViewModelCont
                     });
         }
     }
-
     @Override
     public void destroy() {
     }

--- a/app/src/main/res/layout/activity_reply.xml
+++ b/app/src/main/res/layout/activity_reply.xml
@@ -33,6 +33,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/toot"
+        android:textSize="16sp"
+        android:textColor="#FFFFFF"
+        android:background="@color/colorToot"
         android:layout_below="@+id/status_et"
         android:layout_alignParentRight="true"
         android:layout_alignParentEnd="true"
@@ -43,6 +46,7 @@
         android:layout_below="@id/status_et"
         android:layout_toLeftOf="@id/send_button"
         android:layout_toStartOf="@id/send_button"
+        android:layout_marginRight="14dp"
         android:textColor='@{viewModel.remainingChars &gt; -1 ? @color/colorPrimary : @color/colorRed }'
         android:text="@{viewModel.remainingCharsText}"
         android:layout_width="wrap_content"
@@ -61,6 +65,17 @@
         android:layout_alignParentStart="true" />
 
     <CheckBox
+        android:text="@string/content_warning"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checked="@={viewModel.showContentWarning}"
+        android:layout_below="@+id/public_timeline_ck"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:id="@+id/spoiler_ck"
+        style="@style/Widget.AppCompat.CompoundButton.CheckBox" />
+
+    <CheckBox
         android:id="@+id/public_timeline_ck"
         android:checked="@={viewModel.notDisplayPublic}"
         android:visibility="@{viewModel.isPrivate ? VIEW.GONE : VIEW.VISIBLE}"
@@ -71,5 +86,18 @@
         android:layout_below="@+id/private_ck"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true" />
+
+    <EditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="@{viewModel.showContentWarning ? VIEW.VISIBLE : VIEW.GONE}"
+        android:text="@={viewModel.spoilerText}"
+        android:ems="10"
+        android:id="@+id/content_warning_et"
+        android:layout_below="@+id/spoiler_ck"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:inputType="textCapSentences|textMultiLine"
+        android:hint="@string/content_warning_hint" />
 </RelativeLayout>
 </layout>

--- a/app/src/main/res/layout/item_toot.xml
+++ b/app/src/main/res/layout/item_toot.xml
@@ -130,6 +130,7 @@
             android:layout_alignLeft="@id/avatar_iv"
             android:layout_alignRight="@id/content_tv"
             android:layout_below="@id/content_tv"
+            android:layout_marginTop="5dp"
             android:layout_marginBottom="5dp"
             android:orientation="horizontal" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,7 +3,7 @@
     <color name="colorPrimary">#282c37</color>
     <color name="colorPrimaryDark">#2f3441</color>
     <color name="colorAccent">#FFFFFF</color>
-    <color name="colorToot">#489FDE</color>
+    <color name="colorToot">#2588d0</color>
     <color name="colorRed">#FF0000</color>
     <color name="colorLink">#d9e1e8</color>
     <color name="colorTextPrimary">#ffffff</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,9 +8,13 @@
     <string name="authKey">AUTH_KEY</string>
     <string name="statusId">STATUSID</string>
     <string name="toot_hint">What is on your mind?</string>
+    <string name="content_warning_hint">Content warning</string>
     <string name="toot">Toot</string>
     <string name="mark_as_private">Mark as private</string>
     <string name="do_not_display_in_public_timeline">Do not display in public timeline</string>
+    <string name="content_warning">Hide behind content warning</string>
+    <string name="show_content_warning">Show content</string>
+    <string name="hide_content_warning">Hide content</string>
     <string name="CURRENT_USERNAME">CURRENT_USERNAME</string>
     <string name="login_failed_message">Couldn\'t log in</string>
     <string name="NO_USERNAME_ERROR">You must enter a username</string>


### PR DESCRIPTION
First of all, sorry for the other pull request. Still trying to figure out git and I did some mistakes with the first one. Hope you can forgive me.

These changes add the ability for users to add content warnings using mastodons new spoiler system. It adds a new checkbox plus input box to the toot composer and has the newly added API calls.
The next step would be to actually implement content warnings on the timeline itself.

I also went ahead and fixed the weird padding that occurred after most toots. The code now strips the double new line from each toot that has it.
The timeline now looks a lot cleaner. 
