### PR TITLE
Fix content warning in thread view

### DIFF
--- a/app/src/main/java/eu/theinvaded/mastondroid/viewmodel/ItemTootViewModel.java
+++ b/app/src/main/java/eu/theinvaded/mastondroid/viewmodel/ItemTootViewModel.java
@@ -13,6 +13,7 @@ import android.text.Spannable;
 import android.text.Spanned;
 import android.text.SpannableStringBuilder;
 import android.text.TextPaint;
+import android.text.TextUtils;
 import android.text.style.ClickableSpan;
 import android.text.style.URLSpan;
 import android.text.style.UnderlineSpan;
@@ -179,7 +180,7 @@ public class ItemTootViewModel extends BaseObservable implements TootViewModelCo
             spoilerText = toot.spoiler_text;
         }
 
-        if (spoilerText != "") {
+        if (!TextUtils.isEmpty(spoilerText)) {
             hasContentWarning.set(true);
             showContent.set(false);
         } else {


### PR DESCRIPTION
I overlooked a flaw in the last changes:
Spoilertext would in some cases return null, which means that if you clicked on a toot to open the thread view, that toot would always have a content warning applied even if it didn't have one.
It's fixed now, sorry for the trouble