### PR TITLE
Remove Fabric secret

### DIFF
--- a/app/fabric.properties
+++ b/app/fabric.properties
@@ -1,3 +1,3 @@
 #Contains API Secret used to validate your application. Commit to internal source control; avoid making secret public.
 #Tue Dec 27 23:14:47 EET 2016
-apiSecret=215db88c234f9872f11bc8bb16e2b9d7b1df1f2f592bc0eb2d7a9392ad6676e3
+apiSecret=


### PR DESCRIPTION
Don't know how aware you are of this or if it was on purpose, but if it wasn't perhaps removing the `api secret` for `Fabric` from the open repo, invalidating the current one and generating a new one might be a good idea.

If it was intentional then by all means feel free to close this.